### PR TITLE
json+hex input gen for proof systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ api
 core
 google
 __pycache__
+Prover.toml

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ api
 core
 google
 __pycache__
-Prover.toml
+input.json

--- a/main.py
+++ b/main.py
@@ -131,7 +131,7 @@ if __name__ == "__main__":
 
     blocks = []
             
-    for offset in range(27):
+    for offset in range(18):
         prev_block_hash = get_block_by_number(start_block+offset-1).blockid
         block = get_block_by_number(start_block+offset)
 
@@ -143,7 +143,7 @@ if __name__ == "__main__":
         raw_data = block.block_header.raw_data.SerializeToString()
         tx_root = block.block_header.raw_data.txTrieRoot
         public_key = verify_block_header(prev_block_hash, block.block_header.SerializeToString())
-        signature = block.block_header.witness_signature
+        signature = block.block_header.witness_signature[:64]
 
         blocks.append({
             "new_block_id": str([str(x) for x in block.blockid]).replace("'", "\""),

--- a/main.py
+++ b/main.py
@@ -127,35 +127,42 @@ def parse_usdt_transfer(tx):
     return sender, to, amount
 
 if __name__ == "__main__":
-    blocks = []
-    if len(sys.argv) > 1:
-        blocks.append(int(sys.argv[1]))
-    else:
-        for i in range(1000):
-            blocks.append(62913164-random.randint(0, 10000))
-            
-    for block_number in blocks:
-        prev_block_hash = get_block_by_number(block_number-1).blockid
-        block = get_block_by_number(block_number)
+    start_block = int(sys.argv[1])
 
-        print("checking block %d..." % block_number)
+    blocks = []
+            
+    for offset in range(27):
+        prev_block_hash = get_block_by_number(start_block+offset-1).blockid
+        block = get_block_by_number(start_block+offset)
+
+        print("checking block %d..." % (start_block+offset))
 
         tx_root = create_tree([sha256(x.transaction.SerializeToString()).digest() for x in block.transactions]).hash
         assert tx_root == block.block_header.raw_data.txTrieRoot
 
-        print("prev block:", prev_block_hash.hex())
-        print("new block:", block.blockid.hex())
-        print("raw data:", block.block_header.raw_data.SerializeToString().hex())
-        print("raw data->tx root:", block.block_header.raw_data.txTrieRoot.hex())
-        print("proposer public key:", verify_block_header(prev_block_hash, block.block_header.SerializeToString()).hex())
-        print("proposer signature:", block.block_header.witness_signature.hex())
+        raw_data = block.block_header.raw_data.SerializeToString()
+        tx_root = block.block_header.raw_data.txTrieRoot
+        public_key = verify_block_header(prev_block_hash, block.block_header.SerializeToString())
+        signature = block.block_header.witness_signature
 
-        print(block.block_header)
-
-        print("\nlooking for USDT transfers...")
-
-        for tx in block.transactions:
-            if not tx.result.result: continue # result is a bool (executed/failed)
-
-            if transfer := parse_usdt_transfer(tx):
-                print("{} -> {} ({} USDT)".format(*transfer))
+        blocks.append({
+            "new_block_id": str([str(x) for x in block.blockid]).replace("'", "\""),
+            "prev_block_id": str([str(x) for x in prev_block_hash]).replace("'", "\""),
+            "public_key": str([str(x) for x in public_key]).replace("'", "\""),
+            "raw_data": str([str(x) for x in raw_data + (b"\x00" * (128-len(raw_data)))]).replace("'", "\""),
+            "raw_data_length": "\"%d\"" % len(raw_data),
+            "signature": str([str(x) for x in signature]).replace("'", "\""),
+            "tx_root": str([str(x) for x in tx_root]).replace("'", "\"")
+        })
+    
+    prover_data = ""
+    prover_data += "new_block_id = " + blocks[-1]["new_block_id"]
+    prover_data += "\nprev_block_id = " + blocks[0]["prev_block_id"]
+    prover_data += "\ntx_roots = [" + ", ".join([x["tx_root"] for x in blocks]) + "]\n"
+    for block in blocks:
+        prover_data += "\n[[blocks]]\n"
+        for key, value in block.items():
+            prover_data += "{} = {}\n".format(key, value)
+        prover_data += "\n"
+    
+    open("Prover.toml", "w").write(prover_data)


### PR DESCRIPTION
the previous script logic fully breaks and is essentially no longer a tron light client. now it generates input for zk tron light clients in json (noir-prover branch generates Prover.toml)